### PR TITLE
Ticket 154/incosistencia novedad post egreso

### DIFF
--- a/benchmarks/javierBangho.json4all
+++ b/benchmarks/javierBangho.json4all
@@ -22,3 +22,4 @@
 ,,,date:2025-06-17,,,tiempos:;,,tamannio:,personas:34,,duracion:7980
 ,,,date:2025-06-19,,,tiempos:;,,tamannio:,personas:34,,duracion:7882
 ,,,date:2025-06-23,,,tiempos:;,,tamannio:,personas:34,,duracion:7820
+,,,date:2025-06-26,,,tiempos:;,,tamannio:,personas:34,,duracion:7733

--- a/benchmarks/javierBangho.json4all
+++ b/benchmarks/javierBangho.json4all
@@ -19,4 +19,6 @@
 ,,,date:2025-06-09,,,tiempos:;,,tamannio:,personas:34,,duracion:8672
 ,,,date:2025-06-10,,,tiempos:;,,tamannio:,personas:34,,duracion:8031
 ,,,date:2025-06-11,,,tiempos:;,,tamannio:,personas:34,,duracion:8012
+,,,date:2025-06-17,,,tiempos:;,,tamannio:,personas:34,,duracion:7980
+,,,date:2025-06-19,,,tiempos:;,,tamannio:,personas:34,,duracion:7882
 ,,,date:2025-06-23,,,tiempos:;,,tamannio:,personas:34,,duracion:7820

--- a/install/pautas.tab
+++ b/install/pautas.tab
@@ -11,3 +11,4 @@ ACTSINSEC|activo sin sector
 ACTSINSIT|activo sin situacion revista
 CUILINV|Cuil invalido o inexistente
 NOVPOSTEGR|Existencia de novedades después de la fecha de egreso
+NOVPREVING|Existencia de novedades previas a la fecha de ingreso

--- a/install/pautas.tab
+++ b/install/pautas.tab
@@ -10,3 +10,4 @@ ANTCOMVSRE|Para activos, la antiguedad computada por suma de rangos no coincide 
 ACTSINSEC|activo sin sector
 ACTSINSIT|activo sin situacion revista
 CUILINV|Cuil invalido o inexistente
+NOVPOSTEGR|Existencia de novedades después de la fecha de egreso

--- a/install/personas_actualizar_novedades_trg.sql
+++ b/install/personas_actualizar_novedades_trg.sql
@@ -31,7 +31,7 @@ $BODY$;
 
 DROP TRIGGER IF EXISTS personas_actualizar_novedades_trg on personas;
 CREATE TRIGGER personas_actualizar_novedades_trg
-  AFTER INSERT OR DELETE OR UPDATE OF activo, registra_novedades_desde
+  AFTER INSERT OR DELETE OR UPDATE OF activo, registra_novedades_desde, fecha_egreso
   ON personas
   FOR EACH ROW
   EXECUTE PROCEDURE personas_actualizar_novedades_trg();

--- a/operaciones/cambios-20250618-pauta-novedad-post-egreso.sql
+++ b/operaciones/cambios-20250618-pauta-novedad-post-egreso.sql
@@ -1,0 +1,6 @@
+SET search_path = siper; 
+SET ROLE siper_owner;
+
+-- Agregar la entrada "cuil invalido"
+INSERT INTO pautas (pauta, descripcion)
+VALUES ('NOVPOSTEGR', 'Existencia de novedades después de la fecha de egreso');

--- a/operaciones/cambios-20250618-pauta-novedad-post-egreso.sql
+++ b/operaciones/cambios-20250618-pauta-novedad-post-egreso.sql
@@ -3,4 +3,6 @@ SET ROLE siper_owner;
 
 -- Agregar la entrada "cuil invalido"
 INSERT INTO pautas (pauta, descripcion)
-VALUES ('NOVPOSTEGR', 'Existencia de novedades después de la fecha de egreso');
+VALUES 
+    ('NOVPOSTEGR', 'Existencia de novedades después de la fecha de egreso');
+    ('NOVPREVING', 'Existencia de novedades previas a la fecha de ingreso');

--- a/src/client/ws-componentes.tsx
+++ b/src/client/ws-componentes.tsx
@@ -278,7 +278,7 @@ function Calendario(props:{conn:Connector, idper:string, fecha: RealDate, fechaH
 
 // @ts-ignore
 type ProvisorioPersonas = {sector?:string, idper:string, apellido:string, nombres:string, cuil:string, ficha?:string, idmeta4?:string, cargable?:boolean, cuil_valido?:boolean, 
-    fecha_ingreso?:RealDate, fecha_egreso?:RealDate /*, activo?:boolean, fecha_nacimiento?:RealDate, nombre_sector?:string, jerarquia?:string, jerarquias__descripcion?:string, cargo_atgc?:string, agrupamiento?:string, tramo?:string, grado?:string, domicilio?:string, nacionalidad?:string, sectores__nombre_sector?:string*/};
+    fecha_ingreso?:RealDate, fecha_egreso?:RealDate, registra_novedades_desde?:RealDate /*, activo?:boolean, fecha_nacimiento?:RealDate, nombre_sector?:string, jerarquia?:string, jerarquias__descripcion?:string, cargo_atgc?:string, agrupamiento?:string, tramo?:string, grado?:string, domicilio?:string, nacionalidad?:string, sectores__nombre_sector?:string*/};
 type ProvisorioPersonaLegajo = ProvisorioPersonas & {tipo_doc:string, documento:string, sector:string, es_jefe:boolean, categoria:string, situacion_revista:string, registra_novedades_desde:RealDate, para_antiguedad_relativa:RealDate, activo:boolean, fecha_ingreso:RealDate, fecha_egreso:RealDate, nacionalidad:string, jerarquia:string, jerarquias__descripcion:string, cargo_atgc:string, agrupamiento:string, tramo:string, grado:string, domicilio:string, fecha_nacimiento:RealDate, sectores__nombre_sector:string}
 type ProvisorioPersonaDomicilio = {idper:string, barrios__nombre_barrio:string,calles__nombre_calle:string, nombre_calle:string, altura:string, piso:string, depto:string, tipos_domicilio__descripcion:string, tipo_domicilio:string, provincias__nombre_provincia:string, provincia:string, barrio:string, codigo_postal:string, localidad:string, nro_item:string, orden:number}
 type ProvisorioPersonaTelefono = {idper: string, tipo_telefono: string, tipos_telefono__descripcion?: string, telefono: string, observaciones?: string, nro_item?: number, orden?: number}
@@ -519,7 +519,7 @@ function NovedadesRegistradas(props:{conn: Connector, idper:string, annio:number
                 .filter(([key, value]) => key.startsWith("dds") && value === true)
                 .map(([key]) => diasSemana[key]);
             const problemas = [
-                persona.fecha_ingreso && n.desde < persona.fecha_ingreso ? "Fecha desde anterior a la fecha de ingreso" : null,
+                persona.registra_novedades_desde && n.desde < persona.registra_novedades_desde ? "Fecha desde anterior a la fecha de ingreso" : null,
                 persona.fecha_egreso && n.hasta > persona.fecha_egreso ? "Fecha hasta posterior a la fecha de egreso" : null,
             ].filter(Boolean);
             return (

--- a/src/server/procedures-principal.ts
+++ b/src/server/procedures-principal.ts
@@ -178,7 +178,7 @@ export const ProceduresPrincipal:ProcedureDef[] = [
         coreFunction: async function(context: ProcedureContext, params:any){
             const info = await context.client.query(
                 `select pe.idper, pe.cuil, pe.ficha, pe.idmeta4, pe.apellido, pe.nombres, pe.sector, cod_nov, novedad, nombre_sector, pe.es_jefe, validar_cuit(pe.cuil) AS cuil_valido,
-                        pe.fecha_ingreso, pe.fecha_egreso,
+                        pe.fecha_ingreso, pe.fecha_egreso, pe.registra_novedades_desde,
                         ((puede_cargar_propio or pe.idper is distinct from u.idper) and (pe.activo is true)) as cargable
                     from personas pe
                         inner join situacion_revista sr using (situacion_revista)

--- a/src/server/table-inconsistencias.ts
+++ b/src/server/table-inconsistencias.ts
@@ -98,9 +98,22 @@ export function inconsistencias(_context: TableContext): TableDefinition{
                      ) q
                      UNION
                      SELECT v.idper, NULL::INTEGER as annio, 'NOVPOSTEGR' pauta, v.cod_nov
-                       FROM novedades_vigentes v
+                       FROM novedades_registradas v
                        JOIN personas p ON v.idper = p.idper
-                       WHERE p.fecha_egreso IS NOT NULL AND v.fecha > p.fecha_egreso 
+                       WHERE p.fecha_egreso IS NOT NULL
+                         AND (
+                               v.desde > p.fecha_egreso
+                            OR (v.hasta IS NOT NULL AND v.hasta > p.fecha_egreso)
+                     )
+                     UNION
+                     SELECT v.idper, NULL::INTEGER as annio, 'NOVPREVING' pauta, v.cod_nov
+                       FROM novedades_registradas v
+                       JOIN personas p ON v.idper = p.idper
+                       WHERE p.registra_novedades_desde IS NOT NULL
+                         AND (
+                               v.desde < p.registra_novedades_desde
+                            OR (v.hasta IS NOT NULL AND v.hasta < p.registra_novedades_desde)
+                         )
             )`
         }
     };

--- a/src/server/table-inconsistencias.ts
+++ b/src/server/table-inconsistencias.ts
@@ -96,6 +96,11 @@ export function inconsistencias(_context: TableContext): TableDefinition{
                        FROM personas
                        WHERE activo AND situacion_revista IS NULL
                      ) q
+                     UNION
+                     SELECT v.idper, NULL::INTEGER as annio, 'NOVPOSTEGR' pauta, v.cod_nov
+                       FROM novedades_vigentes v
+                       JOIN personas p ON v.idper = p.idper
+                       WHERE p.fecha_egreso IS NOT NULL AND v.fecha > p.fecha_egreso 
             )`
         }
     };


### PR DESCRIPTION
-incosistencia novedades posteriores a fecha de egreso
-inconsitencia novedades anteriores a fecha de ingreso
-cambio para que se actualicen novedades vigentes si se modifica fecha egreso
-modifico listado de novedades registradas debajo de calendario para que muestre las novedades anteriores a registra_novedades_desde