### PR TITLE
ticket187 tabla novedades_registradas constrain desde hasta mismo año

### DIFF
--- a/operaciones/cambios-20250710-constraint-novedes-registradas.sql
+++ b/operaciones/cambios-20250710-constraint-novedes-registradas.sql
@@ -1,0 +1,11 @@
+set search_path = siper;
+set role siper_muleto_owner;
+
+DO $$
+BEGIN
+    -- Borra la constraint si existe
+    ALTER TABLE "novedades_registradas" DROP CONSTRAINT IF EXISTS "desde y hasta deben ser del mismo annio";
+
+    -- Agrega la constraint
+    ALTER TABLE "novedades_registradas" ADD CONSTRAINT "desde y hasta deben ser del mismo annio" CHECK (extract(year from desde) is not distinct from extract(year from hasta));
+END $$;

--- a/src/server/table-novedades_registradas.ts
+++ b/src/server/table-novedades_registradas.ts
@@ -97,7 +97,7 @@ export function novedades_registradas(_context: TableContext): TableDefinition{
             {references: 'fechas', fields: [{source:'hasta', target:'fecha'}], alias:'hasta'},
         ],
         constraints: [
-            {constraintType:'check', consName:'desde y hasta deben ser del mismo annio', expr:`extract(year from desde) is not distinct from extract(year from desde)`},
+            {constraintType:'check', consName:'desde y hasta deben ser del mismo annio', expr:`extract(year from desde) is not distinct from extract(year from hasta)`},
             {constraintType:'check', consName:'cod_nov obligatorio si no cancela', expr:'(cod_nov is null) = (cancela is true)'},
         ],
         hiddenColumns: [idr.name],


### PR DESCRIPTION
Había un error en la definición de la constraint, que comparaba el año de desde con sigo mismo.
Lo correcto es que compare el año de "desde" con el año de "hasta".
Ya controle que en producción no hay datos que violen esa constraint. Desde y Hasta son del mismo año.